### PR TITLE
Add flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 _build
 *.install
 *.merlin
+
+# nix build
+/result*

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Online documentation is available [here](https://mirage.github.io/bloomf/).
 
 Alternatively, you can build from sources with `make` or `dune build`.
 
+### Nix
+You can buid the project for different OCaml versions using the [Nix package
+manager][nix]. To list the supported versions, run `nix flake show`. For
+example, to build the project for OCaml version 4.12, run `nix build
+'.#ocamlPackages_4_12-p2pcollab-bloomf'`.
+
+[nix]: https://nixos.org/
+
 ## Tests
 
 Some of the tests, measuring false positive rate or size estimation, might fail

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1620202920,
+        "narHash": "sha256-BOkm3eKT45Dk4NNxJT0xL9NnyYeZcF+t79zPnJkggac=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3c9e33ed627e009428197b07216613206f06ed80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-utils": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1631115497,
+        "narHash": "sha256-q2OzkBy9sQkm6WaXVAJDWwxqn3rnFzdiW79BUmMbKLI=",
+        "ref": "master",
+        "rev": "78571a9b61913143d34a5b692691f52845a6dd18",
+        "revCount": 2,
+        "type": "git",
+        "url": "https://git.sr.ht/~ilkecan/nix-utils"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://git.sr.ht/~ilkecan/nix-utils"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1629880082,
+        "narHash": "sha256-RlQUhZ89btTIINW7xJ4GgX9QE83HhySkliaguz5xUus=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc1a0f56812a26018d19aa6501a8eb1aa3edb6ed",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nix-utils": "nix-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "Efficient Bloom filters for OCaml";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-21.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
+    nix-utils = {
+      url = "git+https://git.sr.ht/~ilkecan/nix-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, nix-utils, ... }@inputs:
+    let
+      inherit (builtins)
+        attrNames
+        attrValues
+      ;
+      inherit (flake-utils.lib)
+        defaultSystems
+        eachSystem
+      ;
+      nix-filter = inputs.nix-filter.lib;
+      inherit (nix-utils.lib)
+        createOcamlOverlays
+        getOcamlPackages
+        getOcamlPackagesFrom
+        getUnstableVersion
+      ;
+
+      supportedSystems = defaultSystems;
+      commonArgs = {
+        version = getUnstableVersion self.lastModifiedDate;
+        homepage = "https://p2pcollab.net/";
+        downloadPage = "https://github.com/p2pcollab/bloomf/releases";
+        changelog = "https://raw.githubusercontent.com/p2pcollab/bloomf/master/CHANGES.md";
+        maintainers = [
+          {
+            name = "ilkecan bozdogan";
+            email = "ilkecan@protonmail.com";
+            github = "ilkecan";
+            githubId = "40234257";
+          }
+        ];
+        platforms = supportedSystems;
+      };
+
+      derivations = {
+        p2pcollab-bloomf = import ./nix/p2pcollab-bloomf.nix commonArgs;
+      };
+    in
+    {
+      overlays = createOcamlOverlays derivations { inherit nix-filter; };
+      overlay = self.overlays.ocamlPackages-p2pcollab-bloomf;
+    } // eachSystem supportedSystems (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = attrValues self.overlays;
+        };
+
+        packageNames = attrNames derivations;
+        defaultOcamlPackages = getOcamlPackagesFrom pkgs packageNames "ocamlPackages";
+      in
+      rec {
+        checks = packages;
+
+        packages = getOcamlPackages pkgs packageNames;
+        defaultPackage = packages.ocamlPackages-p2pcollab-bloomf;
+
+        hydraJobs = {
+          build = defaultOcamlPackages;
+        };
+
+        devShell =
+          let
+            packages = attrValues defaultOcamlPackages;
+          in
+          pkgs.mkShell {
+            inherit packages;
+            inputsFrom = packages;
+          };
+      });
+}

--- a/nix/p2pcollab-bloomf.nix
+++ b/nix/p2pcollab-bloomf.nix
@@ -1,0 +1,72 @@
+{ version
+, homepage
+, downloadPage
+, changelog
+, maintainers
+, platforms
+, runFullTestSuite ? false
+}:
+{ lib
+, nix-filter
+, ocamlPackages
+, ...
+}:
+
+let
+  inherit (nix-filter) inDirectory;
+
+  pname = "bloomf";
+  duneTestCommand = if runFullTestSuite then "build @runtest-rand" else "runtest";
+in
+ocamlPackages.buildDunePackage {
+  inherit pname version;
+
+  src = nix-filter {
+    root = ./..;
+    include = [
+      "${pname}.opam"
+      "dune-project"
+      (inDirectory "src")
+      (inDirectory "test")
+    ];
+    name = "p2pcollab-${pname}";
+  };
+
+  minimumOCamlVersion = "4.03";
+  useDune2 = true;
+
+  dontPatch = true;
+  dontConfigure = true;
+
+  buildInputs = with ocamlPackages; [
+    bitv.out
+  ];
+
+  doCheck = true;
+  checkInputs = with ocamlPackages; [
+    alcotest.out
+  ];
+  checkPhase = ''
+    runHook preCheck
+    dune ${duneTestCommand} -p ${pname} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Efficient Bloom filters for OCaml";
+    longDescription =
+      "Bloom filters are memory and time efficient data structures allowing " +
+      "probabilistic membership queries in a set.\n" +
+      "A query negative result ensures that the element is not present in " +
+      "the set, while a positive result might be a false positive, i.e. the " +
+      "element might not be present and the BF membership query can return " +
+      "true anyway.\n" +
+      "Internal parameters of the BF allow to control its false positive " +
+      "rate depending on the expected number of elements in it.";
+
+    inherit homepage downloadPage changelog;
+
+    license = lib.licenses.mit;
+    inherit maintainers platforms;
+  };
+}


### PR DESCRIPTION
I see that you are familiar with Nix ecosystem. `nix flake show` produces the following output with the added flake:
<details>

<summary>`nix flake show` output</summary>

```
├───checks
│   ├───aarch64-darwin
│   │   ├───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_06-p2pcollab-bloomf: derivation 'ocaml4.06.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_07-p2pcollab-bloomf: derivation 'ocaml4.07.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_08-p2pcollab-bloomf: derivation 'ocaml4.08.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_09-p2pcollab-bloomf: derivation 'ocaml4.09.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_10-p2pcollab-bloomf: derivation 'ocaml4.10.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_11-p2pcollab-bloomf: derivation 'ocaml4.11.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_12-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   └───ocamlPackages_latest-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───aarch64-linux
│   │   ├───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_06-p2pcollab-bloomf: derivation 'ocaml4.06.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_07-p2pcollab-bloomf: derivation 'ocaml4.07.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_08-p2pcollab-bloomf: derivation 'ocaml4.08.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_09-p2pcollab-bloomf: derivation 'ocaml4.09.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_10-p2pcollab-bloomf: derivation 'ocaml4.10.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_11-p2pcollab-bloomf: derivation 'ocaml4.11.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_12-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   └───ocamlPackages_latest-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───i686-linux
│   │   ├───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_05-p2pcollab-bloomf: derivation 'ocaml4.05.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_06-p2pcollab-bloomf: derivation 'ocaml4.06.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_07-p2pcollab-bloomf: derivation 'ocaml4.07.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_08-p2pcollab-bloomf: derivation 'ocaml4.08.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_09-p2pcollab-bloomf: derivation 'ocaml4.09.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_10-p2pcollab-bloomf: derivation 'ocaml4.10.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_11-p2pcollab-bloomf: derivation 'ocaml4.11.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_12-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   └───ocamlPackages_latest-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───x86_64-darwin
│   │   ├───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_05-p2pcollab-bloomf: derivation 'ocaml4.05.0-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_06-p2pcollab-bloomf: derivation 'ocaml4.06.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_07-p2pcollab-bloomf: derivation 'ocaml4.07.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_08-p2pcollab-bloomf: derivation 'ocaml4.08.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_09-p2pcollab-bloomf: derivation 'ocaml4.09.1-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_10-p2pcollab-bloomf: derivation 'ocaml4.10.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_11-p2pcollab-bloomf: derivation 'ocaml4.11.2-bloomf-unstable-2021-09-08'
│   │   ├───ocamlPackages_4_12-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   │   └───ocamlPackages_latest-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   └───x86_64-linux
│       ├───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_05-p2pcollab-bloomf: derivation 'ocaml4.05.0-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_06-p2pcollab-bloomf: derivation 'ocaml4.06.1-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_07-p2pcollab-bloomf: derivation 'ocaml4.07.1-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_08-p2pcollab-bloomf: derivation 'ocaml4.08.1-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_09-p2pcollab-bloomf: derivation 'ocaml4.09.1-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_10-p2pcollab-bloomf: derivation 'ocaml4.10.2-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_11-p2pcollab-bloomf: derivation 'ocaml4.11.2-bloomf-unstable-2021-09-08'
│       ├───ocamlPackages_4_12-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│       └───ocamlPackages_latest-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
├───defaultPackage
│   ├───aarch64-darwin: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───aarch64-linux: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───i686-linux: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───x86_64-darwin: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   └───x86_64-linux: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
├───devShell
│   ├───aarch64-darwin: development environment 'nix-shell'
│   ├───aarch64-linux: development environment 'nix-shell'
│   ├───i686-linux: development environment 'nix-shell'
│   ├───x86_64-darwin: development environment 'nix-shell'
│   └───x86_64-linux: development environment 'nix-shell'
├───hydraJobs
│   ├───aarch64-darwin
│   │   └───build
│   │       └───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───aarch64-linux
│   │   └───build
│   │       └───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───i686-linux
│   │   └───build
│   │       └───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   ├───x86_64-darwin
│   │   └───build
│   │       └───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
│   └───x86_64-linux
│       └───build
│           └───ocamlPackages-p2pcollab-bloomf: derivation 'ocaml4.12.0-bloomf-unstable-2021-09-08'
├───overlay: Nixpkgs overlay
├───overlays
│   ├───ocamlPackages-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_00_1-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_01_0-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_02-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_03-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_04-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_05-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_06-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_07-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_08-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_09-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_10-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_11-p2pcollab-bloomf: Nixpkgs overlay
│   ├───ocamlPackages_4_12-p2pcollab-bloomf: Nixpkgs overlay
│   └───ocamlPackages_latest-p2pcollab-bloomf: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    │   ├───ocamlPackages-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_06-p2pcollab-bloomf: package 'ocaml4.06.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_07-p2pcollab-bloomf: package 'ocaml4.07.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_08-p2pcollab-bloomf: package 'ocaml4.08.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_09-p2pcollab-bloomf: package 'ocaml4.09.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_10-p2pcollab-bloomf: package 'ocaml4.10.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_11-p2pcollab-bloomf: package 'ocaml4.11.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_12-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   └───ocamlPackages_latest-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    ├───aarch64-linux
    │   ├───ocamlPackages-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_06-p2pcollab-bloomf: package 'ocaml4.06.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_07-p2pcollab-bloomf: package 'ocaml4.07.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_08-p2pcollab-bloomf: package 'ocaml4.08.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_09-p2pcollab-bloomf: package 'ocaml4.09.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_10-p2pcollab-bloomf: package 'ocaml4.10.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_11-p2pcollab-bloomf: package 'ocaml4.11.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_12-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   └───ocamlPackages_latest-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    ├───i686-linux
    │   ├───ocamlPackages-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_05-p2pcollab-bloomf: package 'ocaml4.05.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_06-p2pcollab-bloomf: package 'ocaml4.06.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_07-p2pcollab-bloomf: package 'ocaml4.07.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_08-p2pcollab-bloomf: package 'ocaml4.08.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_09-p2pcollab-bloomf: package 'ocaml4.09.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_10-p2pcollab-bloomf: package 'ocaml4.10.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_11-p2pcollab-bloomf: package 'ocaml4.11.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_12-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   └───ocamlPackages_latest-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    ├───x86_64-darwin
    │   ├───ocamlPackages-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_05-p2pcollab-bloomf: package 'ocaml4.05.0-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_06-p2pcollab-bloomf: package 'ocaml4.06.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_07-p2pcollab-bloomf: package 'ocaml4.07.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_08-p2pcollab-bloomf: package 'ocaml4.08.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_09-p2pcollab-bloomf: package 'ocaml4.09.1-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_10-p2pcollab-bloomf: package 'ocaml4.10.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_11-p2pcollab-bloomf: package 'ocaml4.11.2-bloomf-unstable-2021-09-08'
    │   ├───ocamlPackages_4_12-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    │   └───ocamlPackages_latest-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
    └───x86_64-linux
        ├───ocamlPackages-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_05-p2pcollab-bloomf: package 'ocaml4.05.0-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_06-p2pcollab-bloomf: package 'ocaml4.06.1-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_07-p2pcollab-bloomf: package 'ocaml4.07.1-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_08-p2pcollab-bloomf: package 'ocaml4.08.1-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_09-p2pcollab-bloomf: package 'ocaml4.09.1-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_10-p2pcollab-bloomf: package 'ocaml4.10.2-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_11-p2pcollab-bloomf: package 'ocaml4.11.2-bloomf-unstable-2021-09-08'
        ├───ocamlPackages_4_12-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
        └───ocamlPackages_latest-p2pcollab-bloomf: package 'ocaml4.12.0-bloomf-unstable-2021-09-08'
```

</details>